### PR TITLE
removed unnecessary semicolon, raised a warning when using with -Wall

### DIFF
--- a/AdjustIo/AIUtil.m
+++ b/AdjustIo/AIUtil.m
@@ -58,7 +58,7 @@ static NSString * const kClientSdk = @"ios2.0.1";
     return [self.class sanitize:string defaultString:@"zz"];
 }
 
-+ (NSString *)sanitize:(NSString *)string defaultString:(NSString *)defaultString; {
++ (NSString *)sanitize:(NSString *)string defaultString:(NSString *)defaultString {
     if (string == nil) {
         return defaultString;
     }


### PR DESCRIPTION
If you use -Wall (with some exceptions) in your project , the semicolon would raise a warning. Since it isn't needed anyway just remove it.
