### PR TITLE
Clarify cents -> whole currency unti change

### DIFF
--- a/doc/migrate.md
+++ b/doc/migrate.md
@@ -65,6 +65,10 @@ without associated event tokens. You might need to create an additional event to
 in your dashboard. The optional transaction ID is now a property of the event
 instance.
 
+*Please note* - the revenue format has been changed from a cent float to a whole 
+currency-unit float. Current revenue tracking must be adjusted to whole currency
+units (i.e., divided by 100) in order to remain consistent.
+
 ##### Before
 
 ```objc


### PR DESCRIPTION
This is to clarify that revenue tracking now expects a float denominated in whole currency units, and not in cents, as was the case pre SDK 4.0.