### PR TITLE
Fix for not default date settings

### DIFF
--- a/Adjust/ADJUtil.m
+++ b/Adjust/ADJUtil.m
@@ -26,6 +26,8 @@ static NSDateFormatter *dateFormat;
 
 + (void) initialize {
     dateFormat = [[NSDateFormatter alloc] init];
+    dateFormat.calendar = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
+    dateFormat.locale = [NSLocale systemLocale];
     [dateFormat setDateFormat:kDateFormat];
 }
 


### PR DESCRIPTION
When user changed Date&Time or Calendar setting in Setting app, date formatting fails sometimes.

For example, When Calendar setting is `Japanese` and 24-Hour Time display setting is OFF,`[ADJUtil formatSeconds1970:now]` returns `0027-08-21T午後11:16:17.552Z+0900`.

`dateFormat.calendar = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];` sets formatter calendar `Gregorian`.Only this line, `[ADJUtil formatSeconds1970:now]` returns `2015-08-21T午後11:18:08.145Z+0900`.

`dateFormat.locale = [NSLocale systemLocale];` sets formatter local generic root local.
Then, `[ADJUtil formatSeconds1970:now]` returns `2015-08-21T23:22:48.590Z+0900` :smile: 

Please Review, Thanks.