### PR TITLE
iOS 8: Use non-deprecated gregorian calendar ID

### DIFF
--- a/Adjust/ADJUtil.m
+++ b/Adjust/ADJUtil.m
@@ -28,7 +28,7 @@ static NSDateFormatter *dateFormat;
     dateFormat = [[NSDateFormatter alloc] init];
 
     if ([NSCalendar instancesRespondToSelector:@selector(calendarWithIdentifier:)]) {
-        dateFormat.calendar = [NSCalendar calendarWithIdentifier:NSGregorianCalendar];
+        dateFormat.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     }
 
     dateFormat.locale = [NSLocale systemLocale];


### PR DESCRIPTION
This has been available going back to iOS 4.