### PR TITLE
Stop logging on assert log level, what should be nothing more than an info

### DIFF
--- a/Adjust/ADJConfig.m
+++ b/Adjust/ADJConfig.m
@@ -78,10 +78,10 @@
         return NO;
     }
     if ([environment isEqualToString:ADJEnvironmentSandbox]) {
-        [logger assert:@"SANDBOX: Adjust is running in Sandbox mode. Use this setting for testing. Don't forget to set the environment to `production` before publishing"];
+        [logger info:@"SANDBOX: Adjust is running in Sandbox mode. Use this setting for testing. Don't forget to set the environment to `production` before publishing"];
         return YES;
     } else if ([environment isEqualToString:ADJEnvironmentProduction]) {
-        [logger assert:@"PRODUCTION: Adjust is running in Production mode. Use this setting only for the build that you want to publish. Set the environment to `sandbox` if you want to test your app!"];
+        [logger info:@"PRODUCTION: Adjust is running in Production mode. Use this setting only for the build that you want to publish. Set the environment to `sandbox` if you want to test your app!"];
         return YES;
     }
     [logger error:@"Unknown environment '%@'", environment];

--- a/AdjustTests/ADJActivityHandlerTests.m
+++ b/AdjustTests/ADJActivityHandlerTests.m
@@ -1495,9 +1495,9 @@ readActivityState:(NSString *)readActivityState
 
     // check environment level
     if ([environment isEqualToString:ADJEnvironmentSandbox]) {
-        aAssert(@"SANDBOX: Adjust is running in Sandbox mode. Use this setting for testing. Don't forget to set the environment to `production` before publishing");
+        aInfo(@"SANDBOX: Adjust is running in Sandbox mode. Use this setting for testing. Don't forget to set the environment to `production` before publishing");
     } else if ([environment isEqualToString:ADJEnvironmentProduction]) {
-        aAssert(@"PRODUCTION: Adjust is running in Production mode. Use this setting only for the build that you want to publish. Set the environment to `sandbox` if you want to test your app!");
+        aInfo(@"PRODUCTION: Adjust is running in Production mode. Use this setting only for the build that you want to publish. Set the environment to `sandbox` if you want to test your app!");
     } else {
         aFail();
     }


### PR DESCRIPTION
I don't know if it's just me, but usually if I tell a SDK to log only warnings / errors / fatal errors, I ACTUALLY want it to log ONLY warnings / errors / fatal errors.