### PR TITLE
Fixing documentation warnings in Xcode Version 7.2 (7C68) / iOS 9.2

### DIFF
--- a/Adjust/ADJConfig.h
+++ b/Adjust/ADJConfig.h
@@ -52,7 +52,7 @@
  * You can increase or reduce the amount of logs from Adjust by passing
  * one of the following parameters. Use Log.ASSERT to disable all logging.
  *
- * @param logLevel The desired minimum log level (default: info)
+ * @var logLevel The desired minimum log level (default: info)
  *     Must be one of the following:
  *      - ADJLogLevelVerbose (enable all logging)
  *      - ADJLogLevelDebug   (enable more logging)
@@ -68,7 +68,7 @@
  * When enabled, events get buffered and only get tracked each
  * minute. Buffered events are still persisted, of course.
  *
- * @param eventBufferingEnabled Enable or disable event buffering
+ * @var eventBufferingEnabled Enable or disable event buffering
  */
 @property (nonatomic, assign) BOOL eventBufferingEnabled;
 
@@ -77,7 +77,7 @@
  *
  * See the AdjustDelegate declaration above for details
  *
- * @param delegate The delegate that might implement the optional delegate
+ * @var delegate The delegate that might implement the optional delegate
  *     methods like adjustAttributionChanged:
  */
 @property (nonatomic, weak) NSObject<AdjustDelegate> *delegate;

--- a/Adjust/ADJEvent.h
+++ b/Adjust/ADJEvent.h
@@ -22,7 +22,7 @@
 /**
  * Create Event object with Event Token.
  *
- * @param event Event token that is  created in the dashboard
+ * @param eventToken Event token that is  created in the dashboard
  * at http://adjust.com and should be six characters long.
  */
 + (ADJEvent *)eventWithEventToken:(NSString *)eventToken;


### PR DESCRIPTION
In Xcode 7.2 including this library results in warnings in Xcode due to incorrect usage of the HeaderDoc spec ( https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/HeaderDoc/tags/tags.html ).

```
Adjust/Adjust/ADJEvent.h:25:11: Parameter 'event' not found in the function declaration
Adjust/ADJConfig.h:55:5: '@param' command used in a comment that is not attached to a function declaration
Adjust/ADJConfig.h:71:5: '@param' command used in a comment that is not attached to a function declaration
Adjust/ADJConfig.h:80:5: '@param' command used in a comment that is not attached to a function declaration
```

This PR corrects the usage. 
