### PR TITLE
Fix a memory leak

### DIFF
--- a/Adjust/ADJUtil.m
+++ b/Adjust/ADJUtil.m
@@ -436,6 +436,7 @@ responseDataHandler:(void (^)(ADJResponseData *responseData))responseDataHandler
                                                                               suffixErrorMessage:suffixErrorMessage
                                                                                  activityPackage:activityPackage];
                                       responseDataHandler(responseData);
+                                      [session finishTasksAndInvalidate];
                                   }];
     [task resume];
 }


### PR DESCRIPTION
A memory leak occurs with NSURLSession. I think it have to call `invalidateAndCancel` or `finishTasksAndInvalidate` on the completion handler.