### PR TITLE
Fix constructor signature for suppressed log level code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 ADJConfig *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
                                             environment:environment
-                                   allowSupressLogLevel:YES];
+                                   allowSuppressLogLevel:YES];
 
 [Adjust appDidLaunch:adjustConfig];
 ```


### PR DESCRIPTION
There is a small typo in the signature of the code snippets that results in a broken build upon copy/paste.