### PR TITLE
Fix 'This function declaration is not a prototype' warning

### DIFF
--- a/AdjustBridge/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.h
+++ b/AdjustBridge/WebViewJavascriptBridge/WebViewJavascriptBridge_JS.h
@@ -1,3 +1,3 @@
 #import <Foundation/Foundation.h>
 
-NSString * WebViewJavascriptBridge_js();
+NSString * WebViewJavascriptBridge_js(void);


### PR DESCRIPTION
The following warning is displayed from Xcode9.
```
~/WebViewJavascriptBridge_JS.h:3:38: This function declaration is not a prototype
```

This is the same fix.
https://github.com/marcuswestin/WebViewJavascriptBridge/pull/313