### PR TITLE
Don't include plist files to target. Xcode does it for us

### DIFF
--- a/Adjust.xcodeproj/project.pbxproj
+++ b/Adjust.xcodeproj/project.pbxproj
@@ -214,7 +214,6 @@
 		9DF9C9441D6F3CA5008E362F /* Adjust.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF9C9051D6F3CA5008E362F /* Adjust.m */; };
 		9DF9C9451D6F3CA5008E362F /* ADJUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF9C9061D6F3CA5008E362F /* ADJUtil.h */; };
 		9DF9C9461D6F3CA5008E362F /* ADJUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF9C9071D6F3CA5008E362F /* ADJUtil.m */; };
-		9DF9C9471D6F3CA5008E362F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9DF9C9081D6F3CA5008E362F /* Info.plist */; };
 		9DFA37B71C0F21D600782607 /* AdjustSdk.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DFA37B51C0F21D600782607 /* AdjustSdk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9DFB06131D747070006D48FC /* AdjustSdkTv.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DFB06121D747070006D48FC /* AdjustSdkTv.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9DFB065A1D7470C0006D48FC /* ADJActivityHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DFB061A1D7470C0006D48FC /* ADJActivityHandler.h */; };
@@ -277,7 +276,6 @@
 		9DFB06951D7470C0006D48FC /* Adjust.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFB06561D7470C0006D48FC /* Adjust.m */; };
 		9DFB06961D7470C0006D48FC /* ADJUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DFB06571D7470C0006D48FC /* ADJUtil.h */; };
 		9DFB06971D7470C0006D48FC /* ADJUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFB06581D7470C0006D48FC /* ADJUtil.m */; };
-		9DFB06981D7470C0006D48FC /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9DFB06591D7470C0006D48FC /* Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1644,7 +1642,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9DF9C9471D6F3CA5008E362F /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1652,7 +1649,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9DFB06981D7470C0006D48FC /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AdjustTests/AdjustTestApp/AdjustTestApp.xcodeproj/project.pbxproj
+++ b/AdjustTests/AdjustTestApp/AdjustTestApp.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		6F3A5E8A2018CE14000AACD0 /* ADJResponseData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3A5E632018CE14000AACD0 /* ADJResponseData.m */; };
 		6F3A5E8B2018CE14000AACD0 /* ADJPackageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3A5E652018CE14000AACD0 /* ADJPackageBuilder.m */; };
 		6F3A5E8C2018CE14000AACD0 /* ADJUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3A5E662018CE14000AACD0 /* ADJUserDefaults.m */; };
-		6F3A5E8D2018CE14000AACD0 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6F3A5E6A2018CE14000AACD0 /* Info.plist */; };
 		6F3A5E8E2018CE14000AACD0 /* ADJActivityHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3A5E6C2018CE14000AACD0 /* ADJActivityHandler.m */; };
 		6F3A5E8F2018CE14000AACD0 /* ADJReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3A5E6D2018CE14000AACD0 /* ADJReachability.m */; };
 		6F3A5E9E2018CE3A000AACD0 /* ATLTestInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3A5E912018CE3A000AACD0 /* ATLTestInfo.m */; };
@@ -398,7 +397,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6F3A5E8D2018CE14000AACD0 /* Info.plist in Resources */,
 				6F084237200776A000568A31 /* LaunchScreen.storyboard in Resources */,
 				6F0842342007769F00568A31 /* Assets.xcassets in Resources */,
 				6F0842322007769F00568A31 /* Main.storyboard in Resources */,

--- a/examples/AdjustExample-Swift/AdjustExample-Swift.xcodeproj/project.pbxproj
+++ b/examples/AdjustExample-Swift/AdjustExample-Swift.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		9D449E931E6EDC3D00E7E80B /* ADJTimerOnce.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449E701E6EDC3D00E7E80B /* ADJTimerOnce.m */; };
 		9D449E941E6EDC3D00E7E80B /* Adjust.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449E721E6EDC3D00E7E80B /* Adjust.m */; };
 		9D449E951E6EDC3D00E7E80B /* ADJUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449E741E6EDC3D00E7E80B /* ADJUtil.m */; };
-		9D449E961E6EDC3D00E7E80B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9D449E751E6EDC3D00E7E80B /* Info.plist */; };
 		9DD0E9C11F45879A00B2A759 /* ADJUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD0E9C01F45879A00B2A759 /* ADJUserDefaults.m */; };
 		9DF7A9C61CB4ECA600D3591F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF7A9C51CB4ECA600D3591F /* AppDelegate.swift */; };
 		9DF7A9C81CB4ECA600D3591F /* ViewControllerSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF7A9C71CB4ECA600D3591F /* ViewControllerSwift.swift */; };
@@ -327,7 +326,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D449E961E6EDC3D00E7E80B /* Info.plist in Resources */,
 				9DF7A9D01CB4ECA600D3591F /* LaunchScreen.storyboard in Resources */,
 				9DF7A9CD1CB4ECA600D3591F /* Assets.xcassets in Resources */,
 				9DF7A9CB1CB4ECA600D3591F /* Main.storyboard in Resources */,

--- a/examples/AdjustExample-WebView/AdjustExample-WebView.xcodeproj/project.pbxproj
+++ b/examples/AdjustExample-WebView/AdjustExample-WebView.xcodeproj/project.pbxproj
@@ -52,7 +52,6 @@
 		9D449EF71E6EDD4100E7E80B /* ADJTimerOnce.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449ED41E6EDD4100E7E80B /* ADJTimerOnce.m */; };
 		9D449EF81E6EDD4100E7E80B /* Adjust.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449ED61E6EDD4100E7E80B /* Adjust.m */; };
 		9D449EF91E6EDD4100E7E80B /* ADJUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449ED81E6EDD4100E7E80B /* ADJUtil.m */; };
-		9D449EFA1E6EDD4100E7E80B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9D449ED91E6EDD4100E7E80B /* Info.plist */; };
 		9D75F1961D07463800E5D222 /* WebViewJavascriptBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D75F1881D07463800E5D222 /* WebViewJavascriptBridge.m */; };
 		9D75F1971D07463800E5D222 /* WebViewJavascriptBridge_JS.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D75F18A1D07463800E5D222 /* WebViewJavascriptBridge_JS.m */; };
 		9D75F1981D07463800E5D222 /* WebViewJavascriptBridgeBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D75F18C1D07463800E5D222 /* WebViewJavascriptBridgeBase.m */; };
@@ -421,7 +420,6 @@
 				9D75F19D1D07463800E5D222 /* adjust_config.js in Resources */,
 				9D75F19C1D07463800E5D222 /* adjust_event.js in Resources */,
 				9D75F19B1D07463800E5D222 /* adjust.js in Resources */,
-				9D449EFA1E6EDD4100E7E80B /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/AdjustExample-iWatch/AdjustExample-iWatch.xcodeproj/project.pbxproj
+++ b/examples/AdjustExample-iWatch/AdjustExample-iWatch.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		9D449FC01E6EE72000E7E80B /* ADJTimerOnce.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449F9D1E6EE72000E7E80B /* ADJTimerOnce.m */; };
 		9D449FC11E6EE72000E7E80B /* Adjust.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449F9F1E6EE72000E7E80B /* Adjust.m */; };
 		9D449FC21E6EE72000E7E80B /* ADJUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449FA11E6EE72000E7E80B /* ADJUtil.m */; };
-		9D449FC31E6EE72000E7E80B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9D449FA21E6EE72000E7E80B /* Info.plist */; };
 		9DD0E9C71F45949600B2A759 /* ADJUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD0E9C61F45949600B2A759 /* ADJUserDefaults.m */; };
 		9DF7AC191CB4FEDB00D3591F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF7AC181CB4FEDB00D3591F /* main.m */; };
 		9DF7AC1C1CB4FEDB00D3591F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF7AC1B1CB4FEDB00D3591F /* AppDelegate.m */; };
@@ -502,7 +501,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D449FC31E6EE72000E7E80B /* Info.plist in Resources */,
 				9DF7AC271CB4FEDB00D3591F /* LaunchScreen.storyboard in Resources */,
 				9DF7AC241CB4FEDB00D3591F /* Assets.xcassets in Resources */,
 				9DF7AC221CB4FEDB00D3591F /* Main.storyboard in Resources */,

--- a/examples/AdjustExample-tvOS/AdjustExample-tvOS.xcodeproj/project.pbxproj
+++ b/examples/AdjustExample-tvOS/AdjustExample-tvOS.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		9D449F5C1E6EE6C500E7E80B /* ADJTimerOnce.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449F391E6EE6C500E7E80B /* ADJTimerOnce.m */; };
 		9D449F5D1E6EE6C500E7E80B /* Adjust.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449F3B1E6EE6C500E7E80B /* Adjust.m */; };
 		9D449F5E1E6EE6C500E7E80B /* ADJUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D449F3D1E6EE6C500E7E80B /* ADJUtil.m */; };
-		9D449F5F1E6EE6C500E7E80B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9D449F3E1E6EE6C500E7E80B /* Info.plist */; };
 		9DC95F2F1C10596500138E4B /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DC95F2E1C10596500138E4B /* Constants.m */; };
 		9DD0E9CF1F459ECE00B2A759 /* ADJUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD0E9CE1F459ECE00B2A759 /* ADJUserDefaults.m */; };
 /* End PBXBuildFile section */
@@ -358,7 +357,6 @@
 			files = (
 				963909C21BCC0D8300A2E8A4 /* Assets.xcassets in Resources */,
 				963909C01BCC0D8300A2E8A4 /* Main.storyboard in Resources */,
-				9D449F5F1E6EE6C500E7E80B /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
During compiling in Xcode 10 we have issue
error: Multiple commands produce Info.plist

Fix: uncheck plist files from targets. Xcode will copy them automatically reading plist path from Build settings
https://stackoverflow.com/a/50719379/2035054