### PR TITLE
Alway response adjustDeeplinkResponse callback function on fresh install

### DIFF
--- a/Adjust/ADJActivityHandler.m
+++ b/Adjust/ADJActivityHandler.m
@@ -1051,6 +1051,9 @@ preLaunchActionsArray:(NSArray*)preLaunchActionsArray
     }
 
     if (attributionResponseData.deeplink == nil) {
+        if ([selfI.adjustDelegate respondsToSelector:@selector(adjustDeeplinkResponse:)]) {
+            [selfI.adjustDelegate adjustDeeplinkResponse:attributionResponseData.deeplink];
+        }
         return;
     }
 


### PR DESCRIPTION
The `adjustDeeplinkResponse` callback function will only call on the first install via Adjust deeplink.
And if user install the app without Adjust deeplink, that callback function will not response.

And my problem is: I need to handle the layout for the new user interface in both cases are different.
So, We don't have any other APIs or functions to call direct to check that the device has deferred deeplink.
I found a way to do this to alway response on the fresh install to change this. This will not affect to other cases.