### PR TITLE
Prevent crash when valueDecoded is nil

### DIFF
--- a/Adjust/ADJActivityHandler.m
+++ b/Adjust/ADJActivityHandler.m
@@ -1337,6 +1337,7 @@ remainsPausedMessage:(NSString *)remainsPausedMessage
     if (value.length == 0) return NO;
 
     NSString* valueDecoded = [value adjUrlDecode];
+    if (!valueDecoded) return NO;
 
     NSString* keyWOutPrefix = [keyDecoded substringFromIndex:kAdjustPrefix.length];
     if (keyWOutPrefix.length == 0) return NO;


### PR DESCRIPTION
Hello there 👋.

We at GetYourGuide are using the Adjust iOS SDK.

We've been experiencing a crash, and we found that it can happen when handling a "malformed" URL.

The crash occurs in `ADJActivityHandler`, when it fails to decode a query string parameter value.
The nil `decodedValue` then gets added to the `adjustDeepLinks` dictionary, with
`[adjustDeepLinks setObject:valueDecoded forKey:keyWOutPrefix];`. This causes a crash.

Crash message example:
```
Fatal Exception: NSInvalidArgumentException
*** -[__NSDictionaryM setObject:forKey:]: object cannot be nil (key: deeplink)
-[ADJActivityHandler readDeeplinkQueryStringI:queryString:adjustDeepLinks:attribution:]
```

We added validation to prevent this from happening, returning `NO` if `valueDecoded` is nil.

It is worth mentioning that the `valueDecoded` NSString pointer can be a nil value as `adjUrlDecode` uses the native function `CFURLCreateStringByReplacingPercentEscapes` which can return NULL if it fails to convert the percent escapes to characters.

> A new CFString object, or NULL if the percent escapes cannot be converted to characters, assuming UTF-8 encoding.

We hope that this can help prevent crashes when, for example, an NSURL has percent escapes using UTF-16 encoding.