### PR TITLE
Replaced malloc with secure calloc.

### DIFF
--- a/Adjust/ADJAdditions/UIDevice+ADJAdditions.m
+++ b/Adjust/ADJAdditions/UIDevice+ADJAdditions.m
@@ -135,7 +135,7 @@
 - (NSString *)adjDeviceName {
     size_t size;
     sysctlbyname("hw.machine", NULL, &size, NULL, 0);
-    char *name = malloc(size);
+    char *name = calloc(1, size);
     sysctlbyname("hw.machine", name, &size, NULL, 0);
     NSString *machine = [NSString stringWithUTF8String:name];
     free(name);

--- a/Adjust/ADJSystemProfile.m
+++ b/Adjust/ADJSystemProfile.m
@@ -248,7 +248,7 @@
         return nil;
     }
 
-    char *p = malloc(sizeof(char) * length);
+    char *p = calloc(1, sizeof(char) * length);
     if (p) {
         error = sysctlbyname(name, p, &length, NULL, 0);
     }


### PR DESCRIPTION
 Rationale: Security attacks with an uninitialized memory are easier to obtain information from the memory.

Attack is unlikely in the cases where malloc is used here, but will make security audits easier for users of the SDK