### PR TITLE
Fix AppTrackingTranspaintency.framework typo in README

### DIFF
--- a/doc/korean/README.md
+++ b/doc/korean/README.md
@@ -116,7 +116,7 @@ Apple은 iOS 8을 출시한 후, 임베디드 프레임워크로도 잘 알려�
 - `iAd.framework` - SDK가 실행 중인 ASA 캠페인에 대한 속성을 자동으로 처리하려면 이 프레임워크가 필요합니다.
 - `CoreTelephony.framework` - SDK가 현재의 무선 액세스 기술을 결정하려면 이 프레임워크가 필요합니다.
 - `StoreKit.framework` - `SKAdNetwork` 프레임워크에 액세스하고 Adjust SDK가 iOS 14 및 이후 버전에서 통신을 자동으로 처리하려면 이 프레임워크가 필요합니다.
-- `AppTrackingTranspaintency.framework` - iOS 14 및 이후 버전에서 SDK가 사용자의 추적 동의 다이얼로그를 래핑하고, 추적 여부에 대한 사용자의 동의 값에 대한 액세스를 위해 이 프레임워크가 필요합니다.
+- `AppTrackingTransparency.framework` - iOS 14 및 이후 버전에서 SDK가 사용자의 추적 동의 다이얼로그를 래핑하고, 추적 여부에 대한 사용자의 동의 값에 대한 액세스를 위해 이 프레임워크가 필요합니다.
 
 ### <a id="sdk-integrate"></a>앱에 SDK 연동
 


### PR DESCRIPTION
### Typo

```AppTrackingTranspaintency.framework```
↓
```AppTrackingTransparency.framework```
