### PR TITLE
fix(ADJUtil): iad-adgroup-name: AdGroupName, both capitalizations

### DIFF
--- a/Adjust/ADJUtil.m
+++ b/Adjust/ADJUtil.m
@@ -932,8 +932,10 @@ static NSString * const kDateFormat                 = @"yyyy-MM-dd'T'HH:mm:ss.SS
     }
     // Apple Search Ads fields
     if ([ADJUtil contains:details key:@"iad-adgroup-id" value:@"1234567890"] &&
-        [ADJUtil contains:details key:@"iad-adgroup-name" value:@"AdgroupName"] &&
-        [ADJUtil contains:details key:@"iad-keyword" value:@"Keyword"]) {
+        [ADJUtil contains:details key:@"iad-keyword" value:@"Keyword"] && (
+            [ADJUtil contains:details key:@"iad-adgroup-name" value:@"AdgroupName"] ||
+            [ADJUtil contains:details key:@"iad-adgroup-name" value:@"AdGroupName"]
+        )) {
         [ADJAdjustFactory.logger debug:@"iAd attribution details has dummy Apple Search Ads fields"];
         return NO;
     }


### PR DESCRIPTION
Alternative PR to #523.

After debugging for many hours over the course of a few days, I think I uncovered a typo bug.

### Observed Behavior

![image](https://user-images.githubusercontent.com/834636/112930474-a5b1c400-911a-11eb-84a8-67d18d3cc52c.png)
![image](https://user-images.githubusercontent.com/834636/112930556-cda12780-911a-11eb-94f1-9022577e56e1.png)
![image](https://user-images.githubusercontent.com/834636/112930571-d72a8f80-911a-11eb-843c-4833fe5f6163.png)


Adjust keeps attributing Apple Search Ads with broken / dummy attribution data, even though:
- an Apple Search Ad was never clicked or at least _definitely not_ in the last 7 days
- there is "correct" attribution data in the tracker deep link, which is discarded.

As you can clearly see from the screenshots, the...
- `CampaignName (1234567890)` (`iad-campaign-name`, `iad-campaign-id`)
- `AdGroupName (1234567890)` (`iad-adgroup-name`, `iad-adgroup-id`)

...are _obviously_ invalid dummy data.

I have no clue which event `unknown (12323222)` is supposed to represent, but I can see that `12323222` is the `iad-keyword-id`. Furthermore, it also appears in this log message from https://github.com/adjust/ios_sdk/issues/509#issuecomment-790185733 lamenting a related issue, making it very likely to be some form of dummy data.

### Cause

https://github.com/adjust/ios_sdk/blob/cfbbd189bccc557b98ac08eda81c417b7ef3334a/Adjust/ADJUtil.m#L914-L948

I've placed a breakpoint in `checkAttributionDetails` and after a lot of back and forth found, that the issue is in L935:

https://github.com/adjust/ios_sdk/blob/cfbbd189bccc557b98ac08eda81c417b7ef3334a/Adjust/ADJUtil.m#L933-L939

This compares the value of `iad-adgroup-name` to `AdgroupName`. The intention is to reject attribution details from iAd that are just dummy data. It has a typo. The _actual_ dummy data doesn't use `AdgroupName` with a lower-case `g`, but `AdGroupName` with an upper-case `G`.

```objc
# (lldb) po details
{
    "iad-adgroup-id" = 1234567890;
    "iad-adgroup-name" = AdGroupName;
    "iad-attribution" = true;
    "iad-campaign-id" = 1234567890;
    "iad-campaign-name" = CampaignName;
    "iad-click-date" = "2021-03-30T02:54:34Z";
    "iad-conversion-date" = "2021-03-30T02:54:34Z";
    "iad-conversion-type" = Download;
    "iad-country-or-region" = US;
    "iad-creativeset-id" = 1234567890;
    "iad-creativeset-name" = CreativeSetName;
    "iad-keyword" = Keyword;
    "iad-keyword-id" = 12323222;
    "iad-keyword-matchtype" = Broad;
    "iad-lineitem-id" = 1234567890;
    "iad-lineitem-name" = LineName;
    "iad-org-id" = 1234567890;
    "iad-org-name" = OrgName;
    "iad-purchase-date" = "2021-03-30T02:54:34Z";
}
```

Searching through the issue tracker for `AdGroupName` brings up these issues with log messages, in which you can see, that the capitalization is `AdGroupName` with an upper-case `G`, and not `AdgroupName`: #445, #475, #509

### Fix

From my POV the fix is simply changing the capitalization, as suggested in #523, but this begs the question: How did this _ever_ work before?

Would it be safer to check for both capitalizations? 

As always, the Apple Developer docs around this are "thin" to say the least... I could imagine, that this actually _used to be_ `AdgroupName` with a lower-case `g` and only got changed recently. The three issues I linked are all _relatively_ new. So either this is really because it only got changed a few months ago, or there's now just a higher interest in all of this, e.g. due to ATT & iOS 14.5 or whatever...

In my testing thus far I haven't run into `AdgroupName` at all, but I've only debugged this bit on iOS 14.4.2 yet and currently have no access to devices with a lower iOS version. My iOS 13.7 simulator also uses `AdGroupName`.

So, if you think that we should _replace_ the capitalization, instead of checking for both as done in this PR, I have an alternative PR here: #523