### PR TITLE
Fix: Xcode 13 build errors

### DIFF
--- a/Adjust/Adjust.h
+++ b/Adjust/Adjust.h
@@ -322,7 +322,7 @@ extern NSString * __nonnull const ADJDataResidencyUS;
 /**
  * Obtain singleton Adjust object.
  */
-+ (nullable id)getInstance;
++ (nullable instancetype)getInstance;
 
 - (void)appDidLaunch:(nullable ADJConfig *)adjustConfig;
 

--- a/Adjust/Adjust.m
+++ b/Adjust/Adjust.m
@@ -53,14 +53,14 @@ NSString * const ADJDataResidencyUS = @"DataResidencyUS";
 static Adjust *defaultInstance = nil;
 static dispatch_once_t onceToken = 0;
 
-+ (id)getInstance {
++ (instancetype)getInstance {
     dispatch_once(&onceToken, ^{
         defaultInstance = [[self alloc] init];
     });
     return defaultInstance;
 }
 
-- (id)init {
+- (instancetype)init {
     self = [super init];
     if (self == nil) {
         return nil;


### PR DESCRIPTION
Solve issues below. I'm not super familiar with Objective-C, but my understanding is that `instancetype` is preferred to `id` because it keeps more type information. Please tell me if this is insufficient.

```
Multiple methods named 'attribution' found with mismatched result, parameter type or attributes
Implicit conversion of 'NSURLRequestAttribution' (aka 'enum NSURLRequestAttribution') to 'ADJAttribution * _Nullable' is disallowed with ARC
```

ref: https://github.com/adjust/ios_sdk/issues/546
