### PR TITLE
Support for Xcode 13 beta 3

### DIFF
--- a/Adjust/ADJActivityHandler.h
+++ b/Adjust/ADJActivityHandler.h
@@ -72,7 +72,7 @@
 - (void)launchEventResponseTasks:(ADJEventResponseData * _Nullable)eventResponseData;
 - (void)launchSessionResponseTasks:(ADJSessionResponseData * _Nullable)sessionResponseData;
 - (void)launchSdkClickResponseTasks:(ADJSdkClickResponseData * _Nullable)sdkClickResponseData;
-- (void)launchAttributionResponseTasks:(ADJAttributionResponseData * _Nullable)attributionResponseData;
+- (void)launchAttributionResponseTasks:(ADJAttributionResponseData * _Nullable)attributionResponseData NS_EXTENSION_UNAVAILABLE_IOS("");
 - (void)setEnabled:(BOOL)enabled;
 - (BOOL)isEnabled;
 - (BOOL)isGdprForgotten;

--- a/Adjust/ADJActivityHandler.m
+++ b/Adjust/ADJActivityHandler.m
@@ -102,6 +102,8 @@ static const int kAdServicesdRetriesCount = 1;
 @property (nonatomic, copy) NSString* gdprPath;
 @property (nonatomic, copy) NSString* subscriptionPath;
 
+- (void)prepareDeeplinkI:(ADJActivityHandler *_Nullable)selfI responseData:(ADJAttributionResponseData *_Nullable)attributionResponseData NS_EXTENSION_UNAVAILABLE_IOS("");
+
 @end
 
 // copy from ADClientError

--- a/Adjust/ADJAttributionHandler.h
+++ b/Adjust/ADJAttributionHandler.h
@@ -23,7 +23,7 @@
 
 - (void)checkSdkClickResponse:(ADJSdkClickResponseData *)sdkClickResponseData;
 
-- (void)checkAttributionResponse:(ADJAttributionResponseData *)attributionResponseData;
+- (void)checkAttributionResponse:(ADJAttributionResponseData *)attributionResponseData NS_EXTENSION_UNAVAILABLE_IOS("");
 
 - (void)getAttribution;
 

--- a/Adjust/ADJAttributionHandler.m
+++ b/Adjust/ADJAttributionHandler.m
@@ -28,6 +28,8 @@ static NSString   * const kAttributionTimerName   = @"Attribution timer";
 @property (atomic, assign) BOOL paused;
 @property (nonatomic, copy) NSString *lastInitiatedBy;
 
+- (void)checkAttributionResponseI:(ADJAttributionHandler*)selfI attributionResponseData:(ADJAttributionResponseData *)attributionResponseData NS_EXTENSION_UNAVAILABLE_IOS("");
+
 @end
 
 @implementation ADJAttributionHandler

--- a/Adjust/ADJUtil.h
+++ b/Adjust/ADJUtil.h
@@ -31,13 +31,13 @@ typedef void (^isInactiveInjected)(BOOL);
 
 + (void)excludeFromBackup:(NSString *)filename;
 
-+ (void)launchDeepLinkMain:(NSURL *)deepLinkUrl;
++ (void)launchDeepLinkMain:(NSURL *)deepLinkUrl NS_EXTENSION_UNAVAILABLE_IOS("");
 
 + (void)launchInMainThread:(dispatch_block_t)block;
 
 + (BOOL)isMainThread;
 
-+ (BOOL)isInactive;
++ (BOOL)isInactive NS_EXTENSION_UNAVAILABLE_IOS("");
 
 + (void)launchInMainThreadWithInactive:(isInactiveInjected)isInactiveblock;
 


### PR DESCRIPTION
Annotate code referencing APIs annotated as unavailable for iOS extensions.

Xcode 13 beta 3 introduces a breaking change related to API unavailable for iOS extensions: https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes

This adds the required annotations to all code dependent on APIs unavailable for iOS extensions.