### PR TITLE
Proper URL query encoding

### DIFF
--- a/Adjust/ADJAdditions/NSString+ADJAdditions.m
+++ b/Adjust/ADJAdditions/NSString+ADJAdditions.m
@@ -36,25 +36,11 @@
 }
 
 - (NSString *)adjUrlEncode {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
-                                                                                 NULL,
-                                                                                 (CFStringRef)self,
-                                                                                 NULL,
-                                                                                 (CFStringRef)@"!*'\"();:@&=+$,/?%#[]% ",
-                                                                                 CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding)));
-#pragma clang diagnostic pop
-    // Alternative:
-    // return [self stringByAddingPercentEncodingWithAllowedCharacters:
-    //        [NSCharacterSet characterSetWithCharactersInString:@"!*'\"();:@&=+$,/?%#[]% "]];
+    return [self stringByAddingPercentEncodingWithAllowedCharacters: [NSCharacterSet URLQueryAllowedCharacterSet]];
 }
 
 - (NSString *)adjUrlDecode {
-    return (NSString *)CFBridgingRelease(CFURLCreateStringByReplacingPercentEscapes(
-                                                                                 kCFAllocatorDefault,
-                                                                                 (CFStringRef)self,
-                                                                                 CFSTR("")));
+    return [self stringByRemovingPercentEncoding];
 }
 
 - (NSString *)adjSha256 {


### PR DESCRIPTION
Used `stringByAddingPercentEncodingWithAllowedCharacters ` with `URLQueryAllowedCharacterSet ` as the allowed character set for encoding key/value pairs sent over the URLRequest. This should prevent potentially faulty strings e.g. ones that contain an `&`