### PR TITLE
Replace enum to NS_ENUM

### DIFF
--- a/Adjust/ADJLogger.h
+++ b/Adjust/ADJLogger.h
@@ -7,7 +7,7 @@
 //
 #import <Foundation/Foundation.h>
 
-typedef enum {
+typedef NS_ENUM(NSInteger, ADJLogLevel) {
     ADJLogLevelVerbose  = 1,
     ADJLogLevelDebug    = 2,
     ADJLogLevelInfo     = 3,
@@ -15,7 +15,7 @@ typedef enum {
     ADJLogLevelError    = 5,
     ADJLogLevelAssert   = 6,
     ADJLogLevelSuppress = 7
-} ADJLogLevel;
+};
 
 /**
  * @brief Adjust logger protocol.

--- a/AdjustTests/AdjustTestLibrary/AdjustTestLibrary/ATLControlSignal.h
+++ b/AdjustTests/AdjustTestLibrary/AdjustTestLibrary/ATLControlSignal.h
@@ -10,13 +10,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef enum {
+typedef NS_ENUM(NSInteger, ATLSignalType) {
     ATLSignalTypeInfo               = 1,
     ATLSignalTypeInitTestSession    = 2,
     ATLSignalTypeEndWait            = 3,
     ATLSignalTypeCancelCurrentTest  = 4,
     ATLSignalTypeUnknown            = 5
-} ATLSignalType;
+};
 
 @interface ATLControlSignal : NSObject
 


### PR DESCRIPTION
`typedef enum` cannot use on Swift.
We can use `typedef NS_ENUM` instead of these.

<img width="800" alt="image" src="https://github.com/adjust/ios_sdk/assets/9856514/0f37e563-b9ce-4636-8c21-acdd6675b905">

I used Xcode 14.2 and 14.3 to check.

Thank you!
